### PR TITLE
Remove use of casting to implicitly unwrapped optional

### DIFF
--- a/Source/RPCircularProgress.swift
+++ b/Source/RPCircularProgress.swift
@@ -222,7 +222,7 @@ open class RPCircularProgress: UIView {
             // Basic animations have their value reset to the original once the animation is finished
             // since only the presentation layer is animating
             var currentProgress: CGFloat = 0
-            if let presentationLayer = progressLayer.presentation() as ProgressLayer! {
+            if let presentationLayer = progressLayer.presentation() as? ProgressLayer {
                 currentProgress = presentationLayer.progress
             }
             progressLayer.progress = currentProgress


### PR DESCRIPTION
This pull request contains a change to fix the use of casting to an implicitly unwrapped optional. This will be deprecated in a future Swift release, and this also removes this warning when using this library.